### PR TITLE
feat: make Google OAuth scopes configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ REDIS_PASSWORD= # Redis password
 OAUTH_GOOGLE_CLIENT_ID= # Google OAuth2 client id
 OAUTH_GOOGLE_CLIENT_SECRET= # Google OAuth2 client secret
 OAUTH_GOOGLE_REDIRECT_URI= # Google OAuth2 callback URI eg. http://localhost:8080/oauth/callback
+OAUTH_GOOGLE_SCOPES= # Google OAuth2 scopes (comma-separated) eg. openid,profile,email,https://www.googleapis.com/auth/drive.readonly

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ REDIS_PASSWORD=
 OAUTH_GOOGLE_CLIENT_ID=your-google-client-id
 OAUTH_GOOGLE_CLIENT_SECRET=your-google-client-secret
 OAUTH_GOOGLE_REDIRECT_URI=http://localhost:8080/oauth/callback
+OAUTH_GOOGLE_SCOPES=openid,profile,email
 ```
 
 ### 3. Configure Proxy Routes

--- a/chart/README.md
+++ b/chart/README.md
@@ -125,6 +125,7 @@ The following table lists the configurable parameters and their default values.
 | `config.oauth.google.clientId` | Google OAuth client ID | `""` |
 | `config.oauth.google.clientSecret` | Google OAuth client secret | `""` |
 | `config.oauth.google.redirectUri` | OAuth redirect URI | `http://localhost:8080/oauth/callback` |
+| `config.oauth.google.scopes` | OAuth scopes (comma-separated) | `"openid,profile,email"` |
 | `config.proxies` | Array of proxy configurations | See values.yaml |
 
 ### Service Configuration

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
               key: oauth-google-client-secret
         - name: OAUTH_GOOGLE_REDIRECT_URI
           value: {{ .Values.config.oauth.google.redirectUri | quote }}
+        - name: OAUTH_GOOGLE_SCOPES
+          value: {{ .Values.config.oauth.google.scopes | quote }}
         livenessProbe:
           {{- toYaml .Values.livenessProbe | nindent 12 }}
         readinessProbe:

--- a/chart/values-example.yaml
+++ b/chart/values-example.yaml
@@ -24,6 +24,10 @@ config:
       clientId: "YOUR_GOOGLE_CLIENT_ID"
       clientSecret: "YOUR_GOOGLE_CLIENT_SECRET"
       redirectUri: "https://mcp-gateway.example.com/oauth/callback"
+      # Scopes for Google OAuth
+      # For Google Drive access, add: https://www.googleapis.com/auth/drive.readonly
+      # For Google Calendar access, add: https://www.googleapis.com/auth/calendar.readonly
+      scopes: "openid,profile,email"
 
   # MCP server proxy routes
   proxies:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -135,6 +135,10 @@ config:
       clientId: ""
       clientSecret: ""
       redirectUri: "http://localhost:8080/oauth/callback"
+      # Scopes for Google OAuth (comma-separated)
+      # Default: openid,profile,email
+      # Add additional scopes as needed (e.g., https://www.googleapis.com/auth/drive.readonly)
+      scopes: "openid,profile,email"
 
   # Proxy configuration for MCP servers
   proxies:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - OAUTH_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_CLIENT_ID}
       - OAUTH_GOOGLE_CLIENT_SECRET=${OAUTH_GOOGLE_CLIENT_SECRET}
       - OAUTH_GOOGLE_REDIRECT_URI=${OAUTH_GOOGLE_REDIRECT_URI}
+      - OAUTH_GOOGLE_SCOPES=${OAUTH_GOOGLE_SCOPES:-openid,profile,email}
     depends_on:
       redis:
         condition: service_healthy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type OAuthGoogleConfig struct {
 	GoogleClientID     string `required:"true" envconfig:"OAUTH_GOOGLE_CLIENT_ID"`
 	GoogleClientSecret string `required:"true" envconfig:"OAUTH_GOOGLE_CLIENT_SECRET"`
 	GoogleRedirectURI  string `required:"true" envconfig:"OAUTH_GOOGLE_REDIRECT_URI"`
+	GoogleScopes       string `default:"openid,profile,email" envconfig:"OAUTH_GOOGLE_SCOPES"`
 }
 
 type ProxyConfig struct {

--- a/internal/provider/google/google.go
+++ b/internal/provider/google/google.go
@@ -18,6 +18,7 @@ type GoogleConfig struct {
 	GoogleClientID     string
 	GoogleClientSecret string
 	GoogleRedirectURI  string
+	GoogleScopes       []string
 }
 
 type GoogleProvider struct {
@@ -63,11 +64,16 @@ func NewGoogleProvider(ctx context.Context, config *GoogleConfig, rdb *redis.Cli
 		return nil, fmt.Errorf("failed to create oidc provider: %w", err)
 	}
 
+	scopes := config.GoogleScopes
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email"}
+	}
+
 	oidcConfig := &oauth2.Config{
 		ClientID:     config.GoogleClientID,
 		ClientSecret: config.GoogleClientSecret,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       []string{"openid", "profile", "email"},
+		Scopes:       scopes,
 		RedirectURL:  config.GoogleRedirectURI,
 	}
 


### PR DESCRIPTION
  Add OAUTH_GOOGLE_SCOPES environment variable to configure OAuth scopes across all deployment methods (Docker, Helm, local). Allows users to request additional Google API access (Drive, Calendar, etc.) for MCP servers.

  Changes:
  - Add GoogleScopes field to config and provider structs
  - Parse comma-separated scopes from environment variable
  - Update all configuration files and templates
  - Default to "openid,profile,email" if not specified
